### PR TITLE
Prevents image from being dragged on Firefox

### DIFF
--- a/frontend/src/components/blocks/package/package-widget.tsx
+++ b/frontend/src/components/blocks/package/package-widget.tsx
@@ -86,6 +86,7 @@ export class PackageBlockWidget extends React.Component<PackageBlockWidgetProps>
                                         src={this.props.node.getImage()} 
                                         className='block-package-image' 
                                         draggable={false}
+                                        onDragStart={(e) => { e.preventDefault(); }}
                                         alt={this.props.node.info.name}/>
                                     </ArrowedTooltip>
                                 </div>


### PR DESCRIPTION
Fixes #142 


System | Specification
-- | --
OS | Ubuntu 20.04
Browser | Firefox 99.0

