### PR TITLE
Update Backend Install Instructions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -5,10 +5,11 @@ Django based back-end application for VisualCircuit3.
 ## Setup for development
 
 1. Clone the repository https://github.com/JdeRobot/VisualCircuit.git
-3. Change directory to `backend`
-4. Create a Python3 virtual environment using venv. 
+2. Change directory to `backend`
+3. Create a Python3 virtual environment using venv. 
 For eg. `python -m venv .venv` 
-5. After activating the virtual environment, install the dependencies by running
+4. After activating the virtual environment, install the dependencies by running
 `pip install -r requirements.txt`
-6. Add `.env` file to the `backend` folder. And add the variables as defined in [.env.template](./.env.template)
-7. Start the server by running `python manage.py runserver`
+5. Add `.env` file to the `backend` folder. And add the variables as defined in [.env.template](./.env.template)
+6. Create the static files to serve during execution by `python manage.py collectstatic`
+7. Start the server by running `python manage.py runserver 80`

--- a/docs/_pages/usermanual.md
+++ b/docs/_pages/usermanual.md
@@ -80,7 +80,8 @@ Run VisualCircuit backend:`
 2. Create a Python3 virtual environment using venv. For eg. `python -m venv .venv`
 3. After activating the virtual environment, install the dependencies by running `pip install -r requirements.txt`
 4. Add .env file to the backend folder. And add the variables as defined in .env.template
-5. Start the server by running `python manage.py runserver 80`
+5. Create the static folder which will serve files during execution using `python manage.py collectstatic` 
+6. Start the server by running `python manage.py runserver 80`
 
 
 #### Well Done! you have Successfully Installed the VisualCircuit


### PR DESCRIPTION
The current backend instructions missed a step, namely the user has to run the command:
`python manage.py collectstatic`, this creates the folder from which Django serves the static files during Visual Circuit's execution.

This PR simply adds that step to instructions in both the backend `README` and the website `usermanual.md`