### PR TITLE
Update port used by backend from 80 to 8000

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -12,4 +12,4 @@ For eg. `python -m venv .venv`
 `pip install -r requirements.txt`
 5. Add `.env` file to the `backend` folder. And add the variables as defined in [.env.template](./.env.template)
 6. Create the static files to serve during execution by `python manage.py collectstatic`
-7. Start the server by running `python manage.py runserver 80`
+7. Start the server by running `python manage.py runserver 8000`

--- a/docs/_pages/usermanual.md
+++ b/docs/_pages/usermanual.md
@@ -81,7 +81,7 @@ Run VisualCircuit backend:`
 3. After activating the virtual environment, install the dependencies by running `pip install -r requirements.txt`
 4. Add .env file to the backend folder. And add the variables as defined in .env.template
 5. Create the static folder which will serve files during execution using `python manage.py collectstatic` 
-6. Start the server by running `python manage.py runserver 80`
+6. Start the server by running `python manage.py runserver 8000`
 
 
 #### Well Done! you have Successfully Installed the VisualCircuit

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,1 +1,1 @@
-REACT_APP_BACKEND_HOST=http://localhost:80/api/
+REACT_APP_BACKEND_HOST=http://localhost:8000/api/


### PR DESCRIPTION
Using port 80 for the backend server forces the user to run the command `sudo python3 manage.py runserver` as port 80 is a reserved port by the system.
Changing to port 8000 will clear some permission issues that can occur with port 80 and allow the user the run the command without superuser privileges. 

I've also updated the instructions to reflect the new port.