### PR TITLE
Add read_string and share_string functions

### DIFF
--- a/backend/staticfiles/synthesis/lib/inputs.py
+++ b/backend/staticfiles/synthesis/lib/inputs.py
@@ -66,6 +66,26 @@ class Inputs:
 
         return number
 
+    def read_string(self, name):
+        if self.inputs.get(name) is None:
+            raise InvalidInputNameException(f"{name} is not declared in inputs")
+
+        string = None
+        if self.inputs[name].get("created", False):
+            print(self.inputs[name]["data"])
+            string = create_ndbuffer((1,), '<U64', self.inputs[name]["data"].buf)
+        else:
+            wire_name = self.inputs[name]["wire"]
+            data_wire = create_readonly_wire(wire_name)
+            if data_wire is None:
+                return None
+            self.inputs[name]["data"] = data_wire
+            print(data_wire.buf)
+            string = create_ndbuffer((1,), '<U64', data_wire.buf)
+            self.inputs[name]["created"] = True
+        
+        return string
+
     def read_array(self, name):
         if self.inputs.get(name) is None:
             raise InvalidInputNameException(f"{name} is not declared in inputs")

--- a/backend/staticfiles/synthesis/lib/inputs.py
+++ b/backend/staticfiles/synthesis/lib/inputs.py
@@ -72,7 +72,6 @@ class Inputs:
 
         string = None
         if self.inputs[name].get("created", False):
-            print(self.inputs[name]["data"])
             string = create_ndbuffer((1,), '<U64', self.inputs[name]["data"].buf)
         else:
             wire_name = self.inputs[name]["wire"]
@@ -80,7 +79,6 @@ class Inputs:
             if data_wire is None:
                 return None
             self.inputs[name]["data"] = data_wire
-            print(data_wire.buf)
             string = create_ndbuffer((1,), '<U64', data_wire.buf)
             self.inputs[name]["created"] = True
         

--- a/backend/staticfiles/synthesis/lib/outputs.py
+++ b/backend/staticfiles/synthesis/lib/outputs.py
@@ -70,6 +70,23 @@ class Outputs:
             self.outputs[name]["data"][:] = number
             self.outputs[name]["created"] = True
 
+    def share_string(self, name, string):
+        if self.outputs.get(name) is None:
+            raise InvalidOutputNameException(f"{name} is not declared in outputs")
+
+        if self.outputs[name].get("created", False):
+            self.outputs[name]["data"][:] = string
+        else:
+            wire_name = self.outputs[name]["wire"]
+            data_wire = self._create_wire(
+                wire_name, np.array(string, dtype='<U64').nbytes
+            )
+            self.outputs[name]["data"] = create_ndbuffer(
+                (1,), '<U64', data_wire.buf
+            )
+            self.outputs[name]["data"][:] = string
+            self.outputs[name]["created"] = True
+
     def share_array(self, name, array):
         if self.outputs.get(name) is None:
             raise InvalidOutputNameException(f"{name} is not declared in outputs")


### PR DESCRIPTION
This PR will add functionality that lets the user use strings for transferring data between blocks.

Currently, the string can be submitted in two forms:
```python
data = "Hello"
outputs.share_string("Out", data)
```
```python
data = ["Hello"]
outputs.share_string("Out", data)
```
Both will work, however, if the array has more than 1 element then it will give an error