### PR TITLE
Fix read_number function 

### DIFF
--- a/backend/staticfiles/synthesis/lib/inputs.py
+++ b/backend/staticfiles/synthesis/lib/inputs.py
@@ -53,16 +53,15 @@ class Inputs:
 
         number = None
         if self.inputs[name].get("created", False):
-            number = self.inputs[name]["data"][:][0]
+            number = create_ndbuffer((1,), np.float64, self.inputs[name]["data"].buf)
         else:
             wire_name = self.inputs[name]["wire"]
             data_wire = create_readonly_wire(wire_name)
-            if data_wire is not None:
-                self.inputs[name]["data"] = create_ndbuffer(
-                    (1,), np.float64, data_wire.buf
-                )
-                number = self.inputs[name]["data"][:][0]
-                self.inputs[name]["created"] = True
+            if data_wire is None:
+                return None
+            self.inputs[name]["data"] = data_wire
+            number = create_ndbuffer((1,), np.float64, data_wire.buf)
+            self.inputs[name]["created"] = True
 
         return number
 


### PR DESCRIPTION
Key change was:
```python
if self.inputs[name].get("created", False):
            # Read number from SHM buffer in "data"
            number = create_ndbuffer((1,), np.float64, self.inputs[name]["data"].buf)
# And in the else statement
self.inputs[name]["data"] = data_wire # Stores the SHM Object in "data"
```

This enables us to get the output properly:
![image](https://user-images.githubusercontent.com/31101072/178207658-d32c1290-902c-413d-b474-4913f3d4e2a7.png)

Fix #164 