### PR TITLE
Update Basic Code Template 

### DIFF
--- a/frontend/src/components/blocks/basic/code/code-model.ts
+++ b/frontend/src/components/blocks/basic/code/code-model.ts
@@ -41,7 +41,7 @@ export class CodeBlockModel extends BaseModel<CodeBlockData, NodeModelGenerics &
         });
         // default code shown on editor
         const code = (
-`def loop(block_name, input_wires, output_wires, parameters, flags):
+`def main(inputs, outputs, parameters, synchronise):
     pass`);
         // Initialise data
         this.data = {


### PR DESCRIPTION
The basic code template currently has its main function as:
```python
def loop(...):
    pass
```
I've changed it to:
```python
def main(...):
    pass
```
For the new version of Visual Circuit