### PR TITLE
Add functions to share any type of data

### DIFF
--- a/backend/staticfiles/synthesis/lib/inputs.py
+++ b/backend/staticfiles/synthesis/lib/inputs.py
@@ -17,6 +17,43 @@ class Inputs:
     def __init__(self, input_data) -> None:
         self.inputs = input_data
 
+    def read(self, name):
+        if self.inputs.get(name) is None:
+            raise InvalidInputNameException(f"{name} is not declared in inputs")
+
+        if self.inputs[name].get("created", False):
+            dim = create_ndbuffer((1,), np.int64, self.inputs[name]["dim"].buf)[:][0]
+            shape = create_ndbuffer((dim,), np.int64, self.inputs[name]["shape"].buf)
+            type = create_ndbuffer((1,), '<U6', self.inputs[name]["type"].buf)[:][0]
+            data = create_ndbuffer(shape, type, self.inputs[name]["data"].buf)
+        else:
+            wire_name = self.inputs[name]["wire"]
+            data_wire = create_readonly_wire(wire_name)
+            dim_wire = create_readonly_wire(wire_name + "_dim")
+            shape_wire = create_readonly_wire(wire_name + "_shape")
+            type_wire = create_readonly_wire(wire_name + "_type")
+
+            if data_wire is None or shape_wire is None or dim_wire is None or type_wire is None:
+                return None
+
+            self.inputs[name]["dim"] = dim_wire
+            dim = create_ndbuffer((1,), np.int64, dim_wire.buf)[:][0]
+
+            self.inputs[name]["type"] = type_wire
+            type = create_ndbuffer((1,), '<U6', type_wire.buf)[:][0]
+            if not type:
+                return None 
+
+            self.inputs[name]["shape"] = shape_wire
+            shape = create_ndbuffer((dim,), np.int64, shape_wire.buf)
+
+            self.inputs[name]["data"] = data_wire
+            data = create_ndbuffer(shape, type[:], data_wire.buf)
+            
+            self.inputs[name]["created"] = True
+
+        return data
+
     def _read_npy_matrix(self, name, dtype):
         if self.inputs[name].get("created", False):
             dim = create_ndbuffer((1,), np.int64, self.inputs[name]["dim"].buf)[:][0]

--- a/backend/staticfiles/synthesis/lib/outputs.py
+++ b/backend/staticfiles/synthesis/lib/outputs.py
@@ -15,6 +15,59 @@ class Outputs:
         self.shms.append(shm)
         return shm
 
+    def check_type(self, typestr):
+
+        chars = int(typestr[2:])
+        if typestr[1] == 'i' or typestr[1] == 'f':
+            suffix_no = chars if chars > 8 else 8
+        elif typestr[1] == 'U' or typestr[1] == 'S':
+            suffix_no = chars if chars > 64 else 64
+        else:
+            suffix_no = chars
+
+        final_type = typestr[:2] + str(suffix_no)
+        return (final_type)
+
+    def share(self, name, data):
+        if self.outputs.get(name) is None:
+            raise InvalidOutputNameException(f"{name} is not declared in outputs")
+        
+        data = np.array(data)
+        shape = np.array(data.shape)
+        dim = np.array([len(shape)])
+        final_type = self.check_type(data.dtype.str)
+        type = np.array([final_type], dtype='<U6')
+        
+        if self.outputs[name].get("created", False):
+            self.outputs[name]["shape"][:] = shape[:]
+            self.outputs[name]["type"][:] = type[:]
+            self.outputs[name]["data"][:] = data[:]
+
+        else:
+            wire_name = self.outputs[name]["wire"]
+            shape_wire = self._create_wire(wire_name + "_shape", shape.nbytes)
+            dim_wire = self._create_wire(wire_name + "_dim", dim.nbytes) 
+            type_wire = self._create_wire(wire_name + "_type", type.nbytes)
+
+            data_size = data.nbytes if data.nbytes > 256 else 256 
+            data_wire = self._create_wire(self.outputs[name]["wire"], data_size)
+
+            self.outputs[name]["dim"] = create_ndbuffer((1,), np.int64, dim_wire.buf)
+            self.outputs[name]["dim"][:] = dim[:]
+
+            self.outputs[name]["type"] = create_ndbuffer((1,), '<U6', type_wire.buf)            
+            self.outputs[name]["type"][:] = type
+
+            self.outputs[name]["shape"] = create_ndbuffer(
+                shape.shape, shape.dtype, shape_wire.buf
+                )
+            self.outputs[name]["shape"][:] = shape[:]
+
+            self.outputs[name]["data"] = create_ndbuffer(shape, type[0], data_wire.buf)
+            self.outputs[name]["data"][:] = data
+        
+            self.outputs[name]["created"] = True
+
     def _share_npy_matrix(self, name, matrix, shape):
         dim = np.array([len(matrix.shape)], dtype=np.int64)
         if self.outputs[name].get("created", False):

--- a/backend/staticfiles/synthesis/lib/outputs.py
+++ b/backend/staticfiles/synthesis/lib/outputs.py
@@ -16,56 +16,65 @@ class Outputs:
         return shm
 
     def check_type(self, typestr):
-
+        # Data types are of the form "<U6", "|u1", "<i8", etc.
+        # Isolates numbers at the end of the data type
         chars = int(typestr[2:])
+        # In case of float and integer data types, default to 64 bit
         if typestr[1] == 'i' or typestr[1] == 'f':
             suffix_no = chars if chars > 8 else 8
+        # In case of Unicode String (U) or String (S) default to 64 chars
         elif typestr[1] == 'U' or typestr[1] == 'S':
             suffix_no = chars if chars > 64 else 64
+        # Otherwise simply let the original number be
         else:
             suffix_no = chars
-
+        # Combine with the type with the appropriate suffix
         final_type = typestr[:2] + str(suffix_no)
         return (final_type)
 
     def share(self, name, data):
         if self.outputs.get(name) is None:
             raise InvalidOutputNameException(f"{name} is not declared in outputs")
-        
+
+        # Store the array data in the appropriate variables
         data = np.array(data)
         shape = np.array(data.shape)
         dim = np.array([len(shape)])
+        # Check if the data type needs modifications, get the modified type after calling the function
         final_type = self.check_type(data.dtype.str)
         type = np.array([final_type], dtype='<U6')
         
         if self.outputs[name].get("created", False):
+            # Do this if wire has been created
+            # Populate SHM buffers with new data on each cycle
             self.outputs[name]["shape"][:] = shape[:]
             self.outputs[name]["type"][:] = type[:]
             self.outputs[name]["data"][:] = data[:]
 
         else:
+            # Create the wires(SHM Objects) to hold the different types 
+            # of info that will be passed to the read function
             wire_name = self.outputs[name]["wire"]
             shape_wire = self._create_wire(wire_name + "_shape", shape.nbytes)
             dim_wire = self._create_wire(wire_name + "_dim", dim.nbytes) 
             type_wire = self._create_wire(wire_name + "_type", type.nbytes)
-
+            # By default allocate 256 bytes to the SHM Object, if the space needed is more then allocate that much space
             data_size = data.nbytes if data.nbytes > 256 else 256 
             data_wire = self._create_wire(self.outputs[name]["wire"], data_size)
 
+            # Create array that accesses SHM Object's buffer to store the dimensions of the data being passed
             self.outputs[name]["dim"] = create_ndbuffer((1,), np.int64, dim_wire.buf)
             self.outputs[name]["dim"][:] = dim[:]
-
+            # Create array that accesses SHM Object's buffer to store the type of the data being passed
             self.outputs[name]["type"] = create_ndbuffer((1,), '<U6', type_wire.buf)            
             self.outputs[name]["type"][:] = type
-
-            self.outputs[name]["shape"] = create_ndbuffer(
-                shape.shape, shape.dtype, shape_wire.buf
-                )
+            # Create array that accesses SHM Object's buffer to store the shape of the data being passed
+            self.outputs[name]["shape"] = create_ndbuffer(shape.shape, shape.dtype, shape_wire.buf)
             self.outputs[name]["shape"][:] = shape[:]
-
+            # Create array that accesses SHM Object's buffer to store the actual data being passed
             self.outputs[name]["data"] = create_ndbuffer(shape, type[0], data_wire.buf)
             self.outputs[name]["data"][:] = data
-        
+            # Mark output as created
             self.outputs[name]["created"] = True
 
     def _share_npy_matrix(self, name, matrix, shape):

--- a/backend/staticfiles/synthesis/main.py
+++ b/backend/staticfiles/synthesis/main.py
@@ -20,6 +20,8 @@ def clean_shared_memory(names):
     all_names = names[:]
     all_names.extend([name + "_dim" for name in names])
     all_names.extend([name + "_shape" for name in names])
+    all_names.extend([name + "_type" for name in names])
+    
     for name in all_names:
         try:
             shm = shared_memory.SharedMemory(name, create=False)


### PR DESCRIPTION
This PR creates functions which will allow users to share any type of data using simple `share()` and `read()` functions as opposed to separate functions like `read_string()`, `share_string()`, `read_number()` etc.

This has been tested with images, numbers and strings on Linux.
