### PR TITLE
Add the .vc3 file to the built application

### DIFF
--- a/backend/synthesis/synthesis.py
+++ b/backend/synthesis/synthesis.py
@@ -14,6 +14,7 @@ OPTIONAL_FILES = {
     'ObjectDetector': 'utils/models/yolov3/*'
 }
 
+PROJECT_FILE_EXTENSION = '.vc3'
 
 def get_number_or_default(num, default):
     try:
@@ -144,6 +145,8 @@ def synthesize(data: dict) -> Tuple[str, BytesIO]:
     zipfile, optional_files = syntheize_modules(data, zipfile)
     zipfile = synthesize_executioner(zipfile, optional_files)
     zipfile = syntesize_extras(zipfile)
+    # Add the .vc3 file to the built application, this will let us easily load the project in Visual Circuit
+    zipfile.append(data['package']['name'] + PROJECT_FILE_EXTENSION, json.dumps(data))
 
     # Project name (zipfile name) 
     project_name = f"{data['package']['name']}.zip" if data['package']['name'] != '' else 'Project.zip'

--- a/backend/synthesis/synthesis.py
+++ b/backend/synthesis/synthesis.py
@@ -145,10 +145,13 @@ def synthesize(data: dict) -> Tuple[str, BytesIO]:
     zipfile, optional_files = syntheize_modules(data, zipfile)
     zipfile = synthesize_executioner(zipfile, optional_files)
     zipfile = syntesize_extras(zipfile)
-    # Add the .vc3 file to the built application, this will let us easily load the project in Visual Circuit
-    zipfile.append(data['package']['name'] + PROJECT_FILE_EXTENSION, json.dumps(data))
 
     # Project name (zipfile name) 
-    project_name = f"{data['package']['name']}.zip" if data['package']['name'] != '' else 'Project.zip'
+    project_name = f"{data['package']['name']}" if data['package']['name'] != '' else 'Project'
+
+    # Add the .vc3 file to the built application, this will let us easily load the project in Visual Circuit
+    zipfile.append(project_name + PROJECT_FILE_EXTENSION, json.dumps(data))
+    # .zip is required for the name of the full package
+    project_name += '.zip'
 
     return project_name, zipfile.get_zip()


### PR DESCRIPTION
Currently, the built application doesn't have the .vc3 file of the project. Hence, it is difficult to edit the project structure on Visual Circuit unless you have a copy.

This PR will build the `.vc3` file along with the application when the user presses 'Build and Download'