### PR TITLE
Added unit conversion feature in constants block and internal code frequency input

### DIFF
--- a/frontend/src/components/blocks/basic/code/code-widget.tsx
+++ b/frontend/src/components/blocks/basic/code/code-widget.tsx
@@ -8,6 +8,7 @@ import { GlobalState } from '../../../../core/store';
 import BaseBlock, { ContextOption } from '../../common/base-block';
 import BasePort from '../../common/base-port';
 import { CodeBlockModel } from './code-model';
+import {unitConversion} from '../../../utils/tooltip/index'
 import './styles.scss';
 
 
@@ -87,7 +88,7 @@ export class CodeBlockWidget extends React.Component<CodeBlockWidgetProps, CodeB
                                     InputProps={{
                                         endAdornment: <InputAdornment position="start">Hz</InputAdornment>,
                                     }}
-                                    type="number"
+                                    type="text"
                                     margin="dense"
                                     value={this.state.frequency}
                                     onChange={this.handleFrequencyInput}
@@ -173,8 +174,9 @@ export class CodeBlockWidget extends React.Component<CodeBlockWidgetProps, CodeB
     }
 
     handleFrequencyInput = (event: ChangeEvent<HTMLInputElement>) => {
+        const actual_val = parseInt(unitConversion(event.target.value), 10);
         this.setState({frequency: event.target.value});
-        this.props.node.data.frequency = event.target.value;
+        this.props.node.data.frequency = actual_val;
     }
 
     /**

--- a/frontend/src/components/blocks/basic/code/code-widget.tsx
+++ b/frontend/src/components/blocks/basic/code/code-widget.tsx
@@ -174,7 +174,7 @@ export class CodeBlockWidget extends React.Component<CodeBlockWidgetProps, CodeB
     }
 
     handleFrequencyInput = (event: ChangeEvent<HTMLInputElement>) => {
-        const actual_val = parseInt(unitConversion(event.target.value), 10);
+        const actual_val = parseFloat(unitConversion(event.target.value));
         this.setState({frequency: event.target.value});
         this.props.node.data.frequency = actual_val;
     }

--- a/frontend/src/components/blocks/basic/code/code-widget.tsx
+++ b/frontend/src/components/blocks/basic/code/code-widget.tsx
@@ -174,8 +174,13 @@ export class CodeBlockWidget extends React.Component<CodeBlockWidgetProps, CodeB
     }
 
     handleFrequencyInput = (event: ChangeEvent<HTMLInputElement>) => {
+        // Convert the input value using a unit conversion function (it returns a string)
         const actual_val = parseFloat(unitConversion(event.target.value));
+
+        // Update the component state with the raw input value
         this.setState({frequency: event.target.value});
+
+        // Update the frequency data in the component's props with the parsed numerical value (actual_val)
         this.props.node.data.frequency = actual_val;
     }
 

--- a/frontend/src/components/blocks/basic/constant/constant-widget.tsx
+++ b/frontend/src/components/blocks/basic/constant/constant-widget.tsx
@@ -99,10 +99,15 @@ export class ConstantBlockWidget extends React.Component<ConstantBlockWidgetProp
      * @param event Change event from constant input field
      */
     handleInput = (event: ChangeEvent<HTMLInputElement>) => {
+        // Convert the input value using a unit conversion function
         const actual_val = unitConversion(event.target.value);
+       
+        // Update the component state with the raw input value
         this.setState({ value: event.target.value});
+       
+        // Check if the component has associated data in its props
         if (this.props.node.data) {
-            this.props.node.data.value = actual_val
+            this.props.node.data.value = actual_val; // Update the value data in the component's props with the converted value
         }
     }
 }

--- a/frontend/src/components/blocks/basic/constant/constant-widget.tsx
+++ b/frontend/src/components/blocks/basic/constant/constant-widget.tsx
@@ -6,6 +6,7 @@ import { GlobalState } from '../../../../core/store';
 import BaseBlock, { ContextOption } from '../../common/base-block';
 import BasePort from '../../common/base-port';
 import { ConstantBlockModel } from './constant-model';
+import {unitConversion} from '../../../utils/tooltip/index'
 import './styles.scss';
 
 /**
@@ -98,9 +99,10 @@ export class ConstantBlockWidget extends React.Component<ConstantBlockWidgetProp
      * @param event Change event from constant input field
      */
     handleInput = (event: ChangeEvent<HTMLInputElement>) => {
-        this.setState({ value: event.target.value });
+        const actual_val = unitConversion(event.target.value);
+        this.setState({ value: event.target.value});
         if (this.props.node.data) {
-            this.props.node.data.value = event.target.value
+            this.props.node.data.value = actual_val
         }
     }
 }

--- a/frontend/src/components/utils/tooltip/index.tsx
+++ b/frontend/src/components/utils/tooltip/index.tsx
@@ -13,33 +13,65 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
 }));
 
+// Function for unit conversion in a given input string
 export const unitConversion  = (input: string): string => {
-    const multiplier: { [key: string]: number } = {
+  
+  // Define a multiplier object for unit conversions
+  const multiplier: { [key: string]: number } = {
         'k': 1000,
         'M': 1000000,
         'm': 0.001,
         'K': 1000,
       };
     
-      const values = input.split(',');
+      const values = input.split(',');  // Split input string by commas to handle multiple values
 
+      // Map over each value to perform unit conversion
       const convertedValues = values.map((value) => {
+
+        /*
+          Regular expression to match and capture components of a value:
+          - ([\d,]*\.?\d+): Captures the numeric part of the value, which may include digits and commas
+                            allowing for thousands separators, and an optional decimal point and fractional part.
+          - ([kKmM]?): Captures the unit part of the value, which may be 'k', 'K', 'm', or 'M', and is optional.
+          - $: Asserts the end of the string, ensuring the match occurs at the end of the value.
+          The result is stored in the 'match' variable, containing an array with the full matched value,
+        */
         const match = value.match(/([\d,]*\.?\d+)([kKmM]?)$/);
         
+        // Check if a match is found
         if (match) {
+
+          // Extract numeric value and unit from the match
           const numericValue = parseFloat(match[1]);
           const unit = match[2] || '';
+
+          // Check if the unit is present in the multiplier object
           if (multiplier.hasOwnProperty(unit)) {
-            const result = numericValue * multiplier[unit];
+
+            // Perform unit conversion and return the result as a string
+            const result = numericValue * multiplier[unit]; 
             return result.toString();
+
           } else {
+
+            // If unit not found, return the numeric value as a string
             return numericValue.toString();
+
           }
         }
     
+        /*
+          Regular expression to add commas to the numeric part of the given 'value'.
+          - (\d): Captures a single digit.
+          - (?=(\d{3})+(?!\d)): This positive lookahead assertion ensures that the digit being considered is part of a sequence where every three digits are followed by another group.
+          - g: Global flag, ensuring this replacement is applied throughout the 'value'.
+          -'$1,': Replaces each captured digit with itself followed by a comma, achieving the separator effect.
+        */
         return value.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
       });
-      return convertedValues.join(',');
+
+      return convertedValues.join(','); // Join the converted values back into a comma-separated string and return
   };
 
 /**

--- a/frontend/src/components/utils/tooltip/index.tsx
+++ b/frontend/src/components/utils/tooltip/index.tsx
@@ -13,6 +13,35 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
 }));
 
+export const unitConversion  = (input: string): string => {
+    const multiplier: { [key: string]: number } = {
+        'k': 1000,
+        'M': 1000000,
+        'm': 0.001,
+        'K': 1000,
+      };
+    
+      const values = input.split(',');
+
+      const convertedValues = values.map((value) => {
+        const match = value.match(/([\d,]*\.?\d+)([kKmM]?)$/);
+        
+        if (match) {
+          const numericValue = parseFloat(match[1]);
+          const unit = match[2] || '';
+          if (multiplier.hasOwnProperty(unit)) {
+            const result = numericValue * multiplier[unit];
+            return result.toString();
+          } else {
+            return numericValue.toString();
+          }
+        }
+    
+        return value.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
+      });
+      return convertedValues.join(',');
+  };
+
 /**
  * 
  * Tooltip with an arrow

--- a/frontend/src/components/utils/tooltip/index.tsx
+++ b/frontend/src/components/utils/tooltip/index.tsx
@@ -31,20 +31,22 @@ export const unitConversion  = (input: string): string => {
 
         /*
           Regular expression to match and capture components of a value:
-          - ([\d,]*\.?\d+): Captures the numeric part of the value, which may include digits and commas
-                            allowing for thousands separators, and an optional decimal point and fractional part.
+          - (-?): Captures an optional negative sign.
+          - (\d*\.?\d+): Captures the numeric part of the value, which may include digits, an optional decimal point,
+                         and 
           - ([kKmM]?): Captures the unit part of the value, which may be 'k', 'K', 'm', or 'M', and is optional.
           - $: Asserts the end of the string, ensuring the match occurs at the end of the value.
           The result is stored in the 'match' variable, containing an array with the full matched value,
         */
-        const match = value.match(/([\d,]*\.?\d+)([kKmM]?)$/);
+        const match = value.match(/(-?)(\d*\.?\d+)([kKmM]?)$/);
         
         // Check if a match is found
         if (match) {
 
-          // Extract numeric value and unit from the match
-          const numericValue = parseFloat(match[1]);
-          const unit = match[2] || '';
+          // Extract negative sign, numeric value, and unit from the match
+          const negativeSign = match[1] || '';
+          const numericValue = parseFloat(negativeSign + match[2]);
+          const unit = match[3] || '';
 
           // Check if the unit is present in the multiplier object
           if (multiplier.hasOwnProperty(unit)) {
@@ -61,14 +63,8 @@ export const unitConversion  = (input: string): string => {
           }
         }
     
-        /*
-          Regular expression to add commas to the numeric part of the given 'value'.
-          - (\d): Captures a single digit.
-          - (?=(\d{3})+(?!\d)): This positive lookahead assertion ensures that the digit being considered is part of a sequence where every three digits are followed by another group.
-          - g: Global flag, ensuring this replacement is applied throughout the 'value'.
-          -'$1,': Replaces each captured digit with itself followed by a comma, achieving the separator effect.
-        */
-        return value.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
+        // Return the original value if it doesn't match the expected format
+        return value;
       });
 
       return convertedValues.join(','); // Join the converted values back into a comma-separated string and return


### PR DESCRIPTION
### Changes Made
1. Implemented the addition of three units: k or K, m, M (representing Thousands, milli, Mega) to facilitate seamless conversion for both constant input and internal code block.
2. Also, added the internal code block frequency section to accept units. If the value is a decimal and close to 0, it will be set to 0 (e.g., 4m).
3. In the Cropper and various other blocks, multiple parameters are included within a single constant. To address this, each value is now separated by commas. Subsequently, the necessary conversions are applied, followed by the reintroduction of commas. This ensures the internal code functions smoothly without encountering any issues.

### Related Issues
Fixes: #271

### Screenshots

(Used all values for example purpose)

Canvas area - Cropper internal block with xywh of 5.73k,0.0012m,12M,248 and frequency 2.46M
![](https://github.com/JdeRobot/VisualCircuit/assets/62588059/26b65bd1-0903-4737-9f5a-f2e78f0e48d5)

data.json- with xywh of 5.73k,0.0012m,12M,248 (5730, 0.0000012, 12000000,248) and frequency 2.46M ( 2460000)
![](https://github.com/JdeRobot/VisualCircuit/assets/62588059/3b540adc-f8cd-4b69-8729-74e5aa3d170f)


Canvas area - Threshold internal block with low of 5.0832K and high of 18m and frequency 3m
![](https://github.com/JdeRobot/VisualCircuit/assets/62588059/bb42dc73-fed4-40c5-b9dc-2e9fa33bc73e)

data.json- with low of 5.0832K (5083.2) and high of 18m (0.0180000) and frequency 3m i.e., 0.003 (0) 
![](https://github.com/JdeRobot/VisualCircuit/assets/62588059/a9438f72-96fa-4b3c-b5b5-4ab879d96ec1)


