### PR TITLE
Added Alt+R and Alt+r as shortcut key for Renaming of blocks

### DIFF
--- a/frontend/src/components/blocks/basic/constant/constant-widget.tsx
+++ b/frontend/src/components/blocks/basic/constant/constant-widget.tsx
@@ -125,7 +125,7 @@ export class ConstantBlockWidget extends React.Component<ConstantBlockWidgetProp
      */
         handleKeyDown = (event: KeyboardEvent) => {
             const { node } = this.props;
-            if (event.altKey && event.key === 'r' && node.isSelected()) {
+            if (event.altKey && (event.key === 'r' || event.key === 'R') && node.isSelected()) {
                 this.props.editor.editNode(node); // Trigger rename action
             }
         }

--- a/frontend/src/components/blocks/basic/constant/constant-widget.tsx
+++ b/frontend/src/components/blocks/basic/constant/constant-widget.tsx
@@ -41,6 +41,14 @@ export class ConstantBlockWidget extends React.Component<ConstantBlockWidgetProp
         };
     }
 
+    componentDidMount() {
+        document.addEventListener('keydown', this.handleKeyDown); // Adding keydown event listener when component mounts
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keydown', this.handleKeyDown); // Removing keydown event listener when component unmounts
+    }
+
     /**
      * Handler for context menu
      * @param key Key cooresponding to the context menu clicked
@@ -110,4 +118,15 @@ export class ConstantBlockWidget extends React.Component<ConstantBlockWidgetProp
             this.props.node.data.value = actual_val; // Update the value data in the component's props with the converted value
         }
     }
+
+        /**
+     * Keydown event handler to listen for Alt+R key combination
+     * @param event Keydown event
+     */
+        handleKeyDown = (event: KeyboardEvent) => {
+            const { node } = this.props;
+            if (event.altKey && event.key === 'r' && node.isSelected()) {
+                this.props.editor.editNode(node); // Trigger rename action
+            }
+        }
 }

--- a/frontend/src/components/blocks/basic/input/input-widget.tsx
+++ b/frontend/src/components/blocks/basic/input/input-widget.tsx
@@ -26,6 +26,14 @@ export class InputBlockWidget extends React.Component<InputBlockWidgetProps> {
 
     readonly contextOptions: ContextOption[] = [{key: 'rename', label: 'Rename'}, {key: 'delete', label: 'Delete'}];
 
+    componentDidMount() {
+        document.addEventListener('keydown', this.handleKeyDown); // Adding keydown event listener when component mounts
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keydown', this.handleKeyDown); // Removing keydown event listener when component unmounts
+    }
+
     /**
      * Handler for context menu
      * @param key Key cooresponding to the context menu clicked
@@ -66,5 +74,16 @@ export class InputBlockWidget extends React.Component<InputBlockWidgetProps> {
                 </div>
             </BaseBlock>
         );
+    }
+
+       /**
+     * Keydown event handler to listen for Alt+R key combination
+     * @param event Keydown event
+     */
+       handleKeyDown = (event: KeyboardEvent) => {
+        const { node } = this.props;
+        if (event.altKey && event.key === 'r' && node.isSelected()) {
+            this.props.editor.editNode(node); // Trigger rename action
+        }
     }
 }

--- a/frontend/src/components/blocks/basic/input/input-widget.tsx
+++ b/frontend/src/components/blocks/basic/input/input-widget.tsx
@@ -82,7 +82,7 @@ export class InputBlockWidget extends React.Component<InputBlockWidgetProps> {
      */
        handleKeyDown = (event: KeyboardEvent) => {
         const { node } = this.props;
-        if (event.altKey && event.key === 'r' && node.isSelected()) {
+        if (event.altKey && (event.key === 'r' || event.key === 'R') && node.isSelected()) {
             this.props.editor.editNode(node); // Trigger rename action
         }
     }

--- a/frontend/src/components/blocks/basic/output/output-widget.tsx
+++ b/frontend/src/components/blocks/basic/output/output-widget.tsx
@@ -25,6 +25,14 @@ export class OutputBlockWidget extends React.Component<OutputBlockWidgetProps> {
 
     readonly contextOptions: ContextOption[] = [{key: 'rename', label: 'Rename'}, {key: 'delete', label: 'Delete'}];
 
+    componentDidMount() {
+        document.addEventListener('keydown', this.handleKeyDown); // Adding keydown event listener when component mounts
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keydown', this.handleKeyDown); // Removing keydown event listener when component unmounts
+    }
+
     /**
      * Handler for context menu
      * @param key Key cooresponding to the context menu clicked
@@ -65,5 +73,16 @@ export class OutputBlockWidget extends React.Component<OutputBlockWidgetProps> {
                 </div>
             </BaseBlock>
         );
+    }
+
+       /**
+     * Keydown event handler to listen for Alt+R key combination
+     * @param event Keydown event
+     */
+       handleKeyDown = (event: KeyboardEvent) => {
+        const { node } = this.props;
+        if (event.altKey && event.key === 'r' && node.isSelected()) {
+            this.props.editor.editNode(node); // Trigger rename action
+        }
     }
 }

--- a/frontend/src/components/blocks/basic/output/output-widget.tsx
+++ b/frontend/src/components/blocks/basic/output/output-widget.tsx
@@ -81,7 +81,7 @@ export class OutputBlockWidget extends React.Component<OutputBlockWidgetProps> {
      */
        handleKeyDown = (event: KeyboardEvent) => {
         const { node } = this.props;
-        if (event.altKey && event.key === 'r' && node.isSelected()) {
+        if (event.altKey && (event.key === 'r' || event.key === 'R') && node.isSelected()) {
             this.props.editor.editNode(node); // Trigger rename action
         }
     }


### PR DESCRIPTION
### Changes Made
1. There are three blocks which has rename functionality ( constant, input and output ), implemented keydown event handler to detect the Alt+R or Alt+r key combination when particular block is selected.
2. Ensured that the shortcut key functionality only works when the lock on internal blocks containing constant, input, or output is opened, preventing any unintended changes to internal blocks with locks.

### Related Issues
Fixes: #282 

### Screenshots
When the lock on an internal block is open, pressing Alt+R opens a dialog box for renaming - Screenshot
![](https://github.com/JdeRobot/VisualCircuit/assets/62588059/b6edd536-a2dd-4d27-b68b-2acc3aebad37)


In the main canvas, after pressing the shortcut key for renaming- Screenshot
![](https://github.com/JdeRobot/VisualCircuit/assets/62588059/bd18f951-14e0-4a66-953c-709e23a1ce03)

