### PR TITLE
fix: clear the project info object

### DIFF
--- a/frontend/src/core/editor.ts
+++ b/frontend/src/core/editor.ts
@@ -121,6 +121,13 @@ class Editor {
      */
     public clearProject(): void {
         this.activeModel = new DiagramModel();
+        this.projectInfo = {
+            'name': '',
+            'version': '',
+            'description': '',
+            'author': '',
+            'image': ''
+        }
         this.engine.setModel(this.activeModel);
     }
 


### PR DESCRIPTION
Issue:
The project info is retained when we use File > New to start a new circuit.
So, this PR fixes it by clearing the info.