### PR TITLE
fix: show only meaningful names for blocks in global input popup

### DIFF
--- a/frontend/src/core/editor.ts
+++ b/frontend/src/core/editor.ts
@@ -157,7 +157,20 @@ class Editor {
         }));
     }
     
+    public getNodeName(nodeType: string): string {
+        if (nodeType === 'basic.input') {
+            return 'Input';
+        } else if (nodeType === 'basic.output') {
+            return 'Output';
+        } else if (nodeType === 'basic.constant') {
+            return 'Parameter';
+        } else if (nodeType === 'basic.code') {
+            return 'Code';
+        }
 
+        return nodeType;
+    }
+    
 
 
     public getGInputsOutput(): [{ indexOne: number, label: string, id:string }[], { indexTwo: number, label: string,id:string }[]] {
@@ -183,7 +196,7 @@ class Editor {
                                 if(node.getType() == 'block.package'){
                                     label = `${options.info.name} -> : ${portOptions.label}`;
                                 }else{
-                                    label = `${node.getType()} -> : ${portOptions.label}`;
+                                    label = `${this.getNodeName(node.getType())} -> : ${portOptions.label}`;
                                 }
                                 valueOne.push({ indexOne, label, id });
                             }
@@ -195,7 +208,7 @@ class Editor {
                             if(node.getType() == 'block.package'){
                                 label = `${options.info.name} -> : ${portOptions.label}`;
                             }else{
-                                label = `${node.getType()} -> : ${portOptions.label}`;
+                                label = `${this.getNodeName(node.getType())} -> : ${portOptions.label}`;
                             }
                             valueTwo.push({ indexTwo, label, id });
                         }

--- a/frontend/src/core/editor.ts
+++ b/frontend/src/core/editor.ts
@@ -181,7 +181,7 @@ class Editor {
                                 let label = ``;
                                 var id = `${options.id}:${portOptions.label}:${linkIds}`;
                                 if(node.getType() == 'block.package'){
-                                    label = `${node.getType()} -> : ${options.info.name} : ${portOptions.label}`;
+                                    label = `${options.info.name} -> : ${portOptions.label}`;
                                 }else{
                                     label = `${node.getType()} -> : ${portOptions.label}`;
                                 }
@@ -193,7 +193,7 @@ class Editor {
                             let label = ``;
                             var id = `${options.id}:${portOptions.label}:${linkIds}`;
                             if(node.getType() == 'block.package'){
-                                label = `${node.getType()} -> : ${options.info.name} : ${portOptions.label}`;
+                                label = `${options.info.name} -> : ${portOptions.label}`;
                             }else{
                                 label = `${node.getType()} -> : ${portOptions.label}`;
                             }


### PR DESCRIPTION
Changes:
![image](https://github.com/user-attachments/assets/d8d25fd7-7dea-4280-8ee1-bf57167a1d52)


The labels are changed to show just a name, instead of 'block......'. The package blocks show only the name and not the type 'block.package'