### PR TITLE
Fixed Failed Fetch Issue

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -147,9 +147,18 @@ STATIC_ROOT = 'static'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 if DEBUG:
-    CORS_ALLOWED_ORIGINS = [
-        env.str('VISUAL_CIRCUIT_FRONTEND_HOST')
-    ]
+    # Accept a comma-separated list of frontend hosts (e.g. http://localhost:4000)
+    # Also automatically append standard fallback ports if the primary port gets busy
+    base_origins = [origin.strip() for origin in env.str('VISUAL_CIRCUIT_FRONTEND_HOST').split(',')]
+    CORS_ALLOWED_ORIGINS = list(base_origins)
+    
+    # If using localhost:4000, dynamically add 4001 and 4002 as fallbacks
+    for origin in base_origins:
+        if origin.endswith(':4000'):
+            CORS_ALLOWED_ORIGINS.extend([
+                origin.replace(':4000', ':4001'),
+                origin.replace(':4000', ':4002')
+            ])
 # if DEBUG:
 #     CORS_ALLOWED_ORIGINS = [
 #         env.str('VISUAL_CIRCUIT_FRONTEND_HOST'),


### PR DESCRIPTION
Hello @jmplaza @javizqh sir,

Previously, when the default frontend port was unavailable, the React development server would automatically suggest running on another port (for example, 4001 or 4002). Although the frontend handled this switch correctly, the Django backend was configured to allow requests from only a single localhost origin. As a result, whenever the frontend changed ports, API requests were blocked due to CORS restrictions, causing the Build and Download feature to fail with a TypeError: Failed to fetch.

The issue stemmed from the backend CORS configuration being limited to one specific origin. When the frontend ran on a different port, that new origin was not included in CORS_ALLOWED_ORIGINS, and the backend rejected the requests.

To fix this, I updated the CORS configuration in backend/settings.py to also accept the common fallback ports (:4001 and :4002). With this change, if the default port is occupied and the frontend switches automatically, the backend will still allow the requests without requiring any manual changes to environment variables.

This improvement ensures a smoother development experience and removes unnecessary friction when standard ports are busy.

Here is a short testing video demonstrating that it works correctly on both ports:
https://drive.google.com/file/d/17Ep7gY37FSukfD5EpdHqx03i1m2FZrcN/view?usp=drive_link