### PR TITLE
Feature: Add clean ImageInvert block to OpenCV collection

### DIFF
--- a/frontend/src/components/blocks/collection/collection-factory.tsx
+++ b/frontend/src/components/blocks/collection/collection-factory.tsx
@@ -37,6 +37,7 @@ export const collectionBlocks: { 'blocks': CollectionBlockType,
                 'edgeDetector': {'label': 'Edge Detector'},
                 'erosion': {'label': 'Erosion'},
                 'faceDetector': {'label': 'Face Detector'},
+                'imageInvert': {'label': 'Image Invert'},
                 'imageRead': {'label': 'Image Read'},
                 'screen': { 'label': 'Screen' },
                 'threshold': {'label': 'Threshold'},
@@ -76,6 +77,7 @@ export const collectionBlocks: { 'blocks': CollectionBlockType,
                 'edgeDetector': {'label': 'Edge Detector'},
                 'erosion': {'label': 'Erosion'},
                 'faceDetector': {'label': 'Face Detector'},
+                'imageInvert': {'label': 'Image Invert'},
                 'threshold': {'label': 'Threshold'},
             }
         },
@@ -159,6 +161,8 @@ export function getCollectionBlock(name: string) {
             return import('./opencv/FaceDetector.json');
         case 'drivers.opencv.imageRead':
             return import('./opencv/ImageRead.json');
+        case 'processing.opencv.imageInvert':
+            return import('./opencv/ImageInvert.json');
         case 'drivers.opencv.screen':
             return import('./opencv/Screen.json');
         case 'processing.opencv.threshold':

--- a/frontend/src/components/blocks/collection/opencv/ImageInvert.json
+++ b/frontend/src/components/blocks/collection/opencv/ImageInvert.json
@@ -1,0 +1,390 @@
+{
+    "editor": {
+        "id": "fcc46630-2083-484d-8d8e-a1dadf60cd01",
+        "locked": false,
+        "offsetX": -12,
+        "offsetY": -67,
+        "zoom": 100,
+        "gridSize": 0,
+        "layers": [
+            {
+                "id": "08be9cb4-4931-4da0-869d-fb16ee8c6976",
+                "type": "diagram-links",
+                "isSvg": true,
+                "transformed": true,
+                "models": {
+                    "676c3cd7-7fcb-4126-a076-1cdf7980bd57": {
+                        "id": "676c3cd7-7fcb-4126-a076-1cdf7980bd57",
+                        "type": "default",
+                        "selected": false,
+                        "source": "1a4663d0-c299-4757-96cc-ddd12f7c03be",
+                        "sourcePort": "4a1be646-43d6-459e-bbf5-b5a7f7fb6119",
+                        "target": "2a466c9d-1eb5-4148-904a-e9a4fa320ad8",
+                        "targetPort": "d78922b4-0c5b-47c8-95af-683fddb133b3",
+                        "points": [
+                            {
+                                "id": "664648a8-4387-4168-91f6-5e7b140bc3df",
+                                "type": "point",
+                                "x": 1368.1500244140625,
+                                "y": 568.5
+                            },
+                            {
+                                "id": "652e9d9f-4489-4efd-bbab-6f8fe77c9387",
+                                "type": "point",
+                                "x": 1453.5,
+                                "y": 563.5
+                            }
+                        ],
+                        "labels": [],
+                        "width": 3,
+                        "color": "gray",
+                        "curvyness": 50,
+                        "selectedColor": "rgb(0,192,255)"
+                    },
+                    "b86e6bb8-1f43-4524-a873-81d9e87707c4": {
+                        "id": "b86e6bb8-1f43-4524-a873-81d9e87707c4",
+                        "type": "default",
+                        "selected": false,
+                        "source": "c686937b-7fcb-438c-8aa7-24f9241b8d13",
+                        "sourcePort": "3749b060-66e8-482c-ba25-67b8c0c50fa0",
+                        "target": "1a4663d0-c299-4757-96cc-ddd12f7c03be",
+                        "targetPort": "2237cab9-6dac-4d8f-8662-37b901c82884",
+                        "points": [
+                            {
+                                "id": "198bd0f3-38b1-4ba6-ae78-120bf0c6f2f9",
+                                "type": "point",
+                                "x": 429.5,
+                                "y": 476.5
+                            },
+                            {
+                                "id": "e0d27c23-12e9-411d-9cbc-1b8c7d231b32",
+                                "type": "point",
+                                "x": 496.5,
+                                "y": 478
+                            }
+                        ],
+                        "labels": [],
+                        "width": 3,
+                        "color": "gray",
+                        "curvyness": 50,
+                        "selectedColor": "rgb(0,192,255)"
+                    },
+                    "c0bf2c55-31f9-43c6-a9ed-0bcf39df4a71": {
+                        "id": "c0bf2c55-31f9-43c6-a9ed-0bcf39df4a71",
+                        "type": "default",
+                        "selected": false,
+                        "source": "b7aacaae-dcb9-446b-a576-45055e4388fe",
+                        "sourcePort": "384a2bea-b8f0-4306-9206-645bb857f46f",
+                        "target": "1a4663d0-c299-4757-96cc-ddd12f7c03be",
+                        "targetPort": "590a765e-fd45-443b-8d30-24ac677dec5c",
+                        "points": [
+                            {
+                                "id": "7326f683-66f3-4cb9-8f0d-2b32785e6a4e",
+                                "type": "point",
+                                "x": 428.5,
+                                "y": 658.5
+                            },
+                            {
+                                "id": "1bca7aa6-3749-43a1-af09-ee92acaebf43",
+                                "type": "point",
+                                "x": 496.5,
+                                "y": 659
+                            }
+                        ],
+                        "labels": [],
+                        "width": 3,
+                        "color": "gray",
+                        "curvyness": 50,
+                        "selectedColor": "rgb(0,192,255)"
+                    }
+                }
+            },
+            {
+                "id": "214f3d94-138b-4c3c-93c7-427b9f29db99",
+                "type": "diagram-nodes",
+                "isSvg": false,
+                "transformed": true,
+                "models": {
+                    "c686937b-7fcb-438c-8aa7-24f9241b8d13": {
+                        "id": "c686937b-7fcb-438c-8aa7-24f9241b8d13",
+                        "type": "basic.input",
+                        "selected": false,
+                        "x": 336,
+                        "y": 450,
+                        "ports": [
+                            {
+                                "id": "3749b060-66e8-482c-ba25-67b8c0c50fa0",
+                                "type": "port.output",
+                                "x": 422,
+                                "y": 469,
+                                "name": "input-out",
+                                "alignment": "right",
+                                "parentNode": "c686937b-7fcb-438c-8aa7-24f9241b8d13",
+                                "links": [
+                                    "b86e6bb8-1f43-4524-a873-81d9e87707c4"
+                                ],
+                                "in": false,
+                                "label": "Img",
+                                "hideLabel": true
+                            }
+                        ],
+                        "data": {
+                            "name": "Img"
+                        }
+                    },
+                    "b7aacaae-dcb9-446b-a576-45055e4388fe": {
+                        "id": "b7aacaae-dcb9-446b-a576-45055e4388fe",
+                        "type": "basic.input",
+                        "selected": false,
+                        "x": 335,
+                        "y": 632,
+                        "ports": [
+                            {
+                                "id": "384a2bea-b8f0-4306-9206-645bb857f46f",
+                                "type": "port.output",
+                                "x": 421,
+                                "y": 651,
+                                "name": "input-out",
+                                "alignment": "right",
+                                "parentNode": "b7aacaae-dcb9-446b-a576-45055e4388fe",
+                                "links": [
+                                    "c0bf2c55-31f9-43c6-a9ed-0bcf39df4a71"
+                                ],
+                                "in": false,
+                                "label": "Enable",
+                                "hideLabel": true
+                            }
+                        ],
+                        "data": {
+                            "name": "Enable"
+                        }
+                    },
+                    "2a466c9d-1eb5-4148-904a-e9a4fa320ad8": {
+                        "id": "2a466c9d-1eb5-4148-904a-e9a4fa320ad8",
+                        "type": "basic.output",
+                        "selected": false,
+                        "x": 1445,
+                        "y": 537,
+                        "ports": [
+                            {
+                                "id": "d78922b4-0c5b-47c8-95af-683fddb133b3",
+                                "type": "port.input",
+                                "x": 1446,
+                                "y": 556,
+                                "name": "output-in",
+                                "alignment": "left",
+                                "parentNode": "2a466c9d-1eb5-4148-904a-e9a4fa320ad8",
+                                "links": [
+                                    "676c3cd7-7fcb-4126-a076-1cdf7980bd57"
+                                ],
+                                "in": true,
+                                "label": "output-in",
+                                "hideLabel": true
+                            }
+                        ],
+                        "data": {
+                            "name": "Out"
+                        }
+                    },
+                    "1a4663d0-c299-4757-96cc-ddd12f7c03be": {
+                        "id": "1a4663d0-c299-4757-96cc-ddd12f7c03be",
+                        "type": "basic.code",
+                        "selected": false,
+                        "x": 488,
+                        "y": 219,
+                        "ports": [
+                            {
+                                "id": "2237cab9-6dac-4d8f-8662-37b901c82884",
+                                "type": "port.input",
+                                "x": 489,
+                                "y": 470.5,
+                                "name": "Img",
+                                "alignment": "left",
+                                "parentNode": "1a4663d0-c299-4757-96cc-ddd12f7c03be",
+                                "links": [
+                                    "b86e6bb8-1f43-4524-a873-81d9e87707c4"
+                                ],
+                                "in": true,
+                                "label": "Img",
+                                "hideLabel": false
+                            },
+                            {
+                                "id": "590a765e-fd45-443b-8d30-24ac677dec5c",
+                                "type": "port.input",
+                                "x": 489,
+                                "y": 651.5,
+                                "name": "Enable",
+                                "alignment": "left",
+                                "parentNode": "1a4663d0-c299-4757-96cc-ddd12f7c03be",
+                                "links": [
+                                    "c0bf2c55-31f9-43c6-a9ed-0bcf39df4a71"
+                                ],
+                                "in": true,
+                                "label": "Enable",
+                                "hideLabel": false
+                            },
+                            {
+                                "id": "4a1be646-43d6-459e-bbf5-b5a7f7fb6119",
+                                "type": "port.output",
+                                "x": 1360.6500244140625,
+                                "y": 561,
+                                "name": "Out",
+                                "alignment": "right",
+                                "parentNode": "1a4663d0-c299-4757-96cc-ddd12f7c03be",
+                                "links": [
+                                    "676c3cd7-7fcb-4126-a076-1cdf7980bd57"
+                                ],
+                                "in": false,
+                                "label": "Out",
+                                "hideLabel": false
+                            }
+                        ],
+                        "data": {
+                            "code": "import cv2\nimport numpy as np\n\ndef main(inputs, outputs, parameters, synchronise):\n    auto_enable = False\n    try:\n        enable = inputs.read_number(\"Enable\")\n    except Exception:\n        auto_enable = True\n\n    while(auto_enable or inputs.read_number('Enable')):\n        frame = inputs.read_image(\"Img\")\n        if frame is None:\n            continue\n\n        inverted_img = cv2.bitwise_not(frame)\n        outputs.share_image('Out', inverted_img)\n        synchronise()",
+                            "frequency": "30",
+                            "params": [],
+                            "ports": {
+                                "in": [
+                                    {
+                                        "name": "Img"
+                                    },
+                                    {
+                                        "name": "Enable"
+                                    }
+                                ],
+                                "out": [
+                                    {
+                                        "name": "Out"
+                                    }
+                                ]
+                            },
+                            "size": {
+                                "width": "500px",
+                                "height": "400px"
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "version": "3.0",
+    "package": {
+        "name": "ImageInvert",
+        "version": "2.0.0",
+        "description": "Inverts the colors of an image.",
+        "author": "Toshan Luktuke, Muhammad Taha Suhail",
+        "image": "data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMjU2IDI1NiIgaGVpZ2h0PSI1MTIiIHZpZXdCb3g9IjAgMCAyNTYgMjU2IiB3aWR0aD0iNTEyIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnPjxnPjxwYXRoIGQ9Im0yMDIuNTgxIDUzLjg1Ny0zMy41MDQtMzMuNTA0aC0xMTUuNjU4djIwNC4zMjFoMTQ5LjE2MnoiIGZpbGw9IiNjZWNlY2UiLz48Zz48cGF0aCBkPSJtMTY5LjA3NyAyMC4zNTNoLTYuNWwzMy41MDQgMzMuNTA0djE3MC44MTdoNi41di0xNzAuODE3eiIgZmlsbD0iI2UyZTJlMiIvPjwvZz48Zz48cGF0aCBkPSJtNTMuNDE5IDIwLjM1M2g2LjV2MjA0LjMyMWgtNi41eiIgZmlsbD0iI2FmYWZhZiIvPjwvZz48ZyBmaWxsPSIjZjhhZjIzIj48cGF0aCBkPSJtNzMuMTYgMTIyLjUxNGgxNi4xMjZ2MTYuMTI2aC0xNi4xMjZ6Ii8+PHBhdGggZD0ibTEwMy42NzIgMTIyLjUxNGg3OS4xNjh2MTYuMTI2aC03OS4xNjh6Ii8+PC9nPjxnPjxjaXJjbGUgY3g9IjEyOCIgY3k9IjU5LjU5MiIgZmlsbD0iIzllOWU5ZSIgcj0iMTIuNzIyIi8+PHBhdGggZD0ibTE0NC44ODggMTAwLjU4NWgtMzMuNzc1di0xNS45NDRjMC02LjgwOCA1LjUxOS0xMi4zMjcgMTIuMzI3LTEyLjMyN2g5LjEyMmM2LjgwOCAwIDEyLjMyNyA1LjUxOSAxMi4zMjcgMTIuMzI3djE1Ljk0NHoiIGZpbGw9IiM2M2JjZTciLz48ZyBmaWxsPSIjM2YzNjc5Ij48cGF0aCBkPSJtMjcuMzIzIDIzNC4xNDdoLTE4LjAwM2MtLjgyOSAwLTEuNS42NzItMS41IDEuNXMuNjcxIDEuNSAxLjUgMS41aDE4LjAwM2MuODI5IDAgMS41LS42NzIgMS41LTEuNXMtLjY3MS0xLjUtMS41LTEuNXoiLz48cGF0aCBkPSJtMjQ2LjY4IDIzNC4xNDdoLTE4LjAwM2MtLjgyOSAwLTEuNS42NzItMS41IDEuNXMuNjcxIDEuNSAxLjUgMS41aDE4LjAwM2MuODI5IDAgMS41LS42NzIgMS41LTEuNXMtLjY3MS0xLjUtMS41LTEuNXoiLz48cGF0aCBkPSJtMjE4LjQ3OSAyMzQuMTQ3aC0xODAuOTU4Yy0uODI5IDAtMS41LjY3Mi0xLjUgMS41cy42NzEgMS41IDEuNSAxLjVoMTgwLjk1OWMuODI5IDAgMS41LS42NzIgMS41LTEuNXMtLjY3Mi0xLjUtMS41MDEtMS41eiIvPjxwYXRoIGQ9Im05LjMyIDIyNi4xNzRoNDQuMDk5IDE0OS4xNjIgNDQuMDk5Yy44MjkgMCAxLjUtLjY3MiAxLjUtMS41cy0uNjcxLTEuNS0xLjUtMS41aC00Mi41OTl2LTE2OS4zMThjMC0uMzk3LS4xNTgtLjc3OS0uNDM5LTEuMDYxbC0zMy41MDQtMzMuNTA0Yy0uMjgxLS4yODEtLjY2My0uNDM5LTEuMDYxLS40MzloLTExNS42NThjLS44MjkgMC0xLjUuNjcyLTEuNSAxLjV2MjAyLjgyMWgtNDIuNTk5Yy0uODI5IDAtMS41LjY3Mi0xLjUgMS41cy42NzEgMS41MDEgMS41IDEuNTAxem0xNjEuMjU3LTIwMi4yIDI4LjM4MyAyOC4zODNoLTI4LjM4M3ptLTExNS42NTgtMi4xMjFoMTEyLjY1OHYzMi4wMDRjMCAuODI4LjY3MSAxLjUgMS41IDEuNWgzMi4wMDR2MTY3LjgxN2gtMTQ2LjE2MnoiLz48cGF0aCBkPSJtODkuMjg2IDEyMS4wMTRoLTE2LjEyNmMtLjgyOSAwLTEuNS42NzItMS41IDEuNXYxNi4xMjVjMCAuODI4LjY3MSAxLjUgMS41IDEuNWgxNi4xMjVjLjgyOSAwIDEuNS0uNjcyIDEuNS0xLjV2LTE2LjEyNWMuMDAxLS44MjgtLjY3MS0xLjUtMS40OTktMS41em0tMS41IDE2LjEyNWgtMTMuMTI2di0xMy4xMjVoMTMuMTI1djEzLjEyNXoiLz48cGF0aCBkPSJtMTgyLjg0IDEyMS4wMTRoLTc5LjE2N2MtLjgyOSAwLTEuNS42NzItMS41IDEuNXYxNi4xMjVjMCAuODI4LjY3MSAxLjUgMS41IDEuNWg3OS4xNjdjLjgyOSAwIDEuNS0uNjcyIDEuNS0xLjV2LTE2LjEyNWMwLS44MjgtLjY3Mi0xLjUtMS41LTEuNXptLTEuNSAxNi4xMjVoLTc2LjE2N3YtMTMuMTI1aDc2LjE2N3oiLz48cGF0aCBkPSJtMTExLjExMiAxMDIuMDg1aDMzLjc3NWMuODI5IDAgMS41LS42NzIgMS41LTEuNXYtMTUuOTQ0YzAtNi40MDctNC4zODctMTEuNzk1LTEwLjMxMS0xMy4zNTYgMy43MDgtMi41NjkgNi4xNDUtNi44NDkgNi4xNDUtMTEuNjkyIDAtNy44NDItNi4zOC0xNC4yMjItMTQuMjIyLTE0LjIyMnMtMTQuMjIyIDYuMzgtMTQuMjIyIDE0LjIyMmMwIDQuODQzIDIuNDM3IDkuMTIzIDYuMTQ1IDExLjY5Mi01LjkyNCAxLjU2MS0xMC4zMTEgNi45NDgtMTAuMzExIDEzLjM1NnYxNS45NDRjLjAwMS44MjguNjczIDEuNSAxLjUwMSAxLjV6bTUuNjY2LTQyLjQ5MmMwLTYuMTg4IDUuMDM0LTExLjIyMiAxMS4yMjItMTEuMjIyIDYuMTg3IDAgMTEuMjIyIDUuMDM0IDExLjIyMiAxMS4yMjJzLTUuMDM1IDExLjIyMS0xMS4yMjIgMTEuMjIxYy02LjE4OCAwLTExLjIyMi01LjAzNC0xMS4yMjItMTEuMjIxem0tNC4xNjYgMjUuMDQ4YzAtNS45NyA0Ljg1Ny0xMC44MjYgMTAuODI3LTEwLjgyNmg5LjEyMmM1Ljk3IDAgMTAuODI3IDQuODU2IDEwLjgyNyAxMC44MjZ2MTQuNDQ0aC0zMC43NzV2LTE0LjQ0NHoiLz48L2c+PC9nPjwvZz48Zz48ZyBmaWxsPSIjYWZhZmFmIj48cGF0aCBkPSJtNTkuOTE5IDEzMi4zNTRoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIvPjxwYXRoIGQ9Im0xMDUuMjY5IDEzMi4zNTRoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIvPjxwYXRoIGQ9Im0xNTAuNjc1IDEzMi4zNTRoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIvPjwvZz48cGF0aCBkPSJtODIuNjIyIDEzMi4zNTRoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIgZmlsbD0iI2NlY2VjZSIvPjxwYXRoIGQ9Im0xMjcuOTcyIDEzMi4zNTRoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIgZmlsbD0iI2NlY2VjZSIvPjxwYXRoIGQ9Im0xNzMuMzc4IDEzMi4zNTRoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIgZmlsbD0iI2NlY2VjZSIvPjwvZz48Zz48ZyBmaWxsPSIjY2VjZWNlIj48cGF0aCBkPSJtNTkuOTE5IDE1NS4wNTdoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIvPjxwYXRoIGQ9Im0xMDUuMjY5IDE1NS4wNTdoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIvPjxwYXRoIGQ9Im0xNTAuNjc1IDE1NS4wNTdoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIvPjwvZz48cGF0aCBkPSJtODIuNjIyIDE1NS4wNTdoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIgZmlsbD0iI2FmYWZhZiIvPjxwYXRoIGQ9Im0xMjcuOTcyIDE1NS4wNTdoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIgZmlsbD0iI2FmYWZhZiIvPjxwYXRoIGQ9Im0xNzMuMzc4IDE1NS4wNTdoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIgZmlsbD0iI2FmYWZhZiIvPjwvZz48Zz48ZyBmaWxsPSIjYWZhZmFmIj48cGF0aCBkPSJtNTkuOTE5IDE3Ny43NmgyMi43MDN2MjIuNzAzaC0yMi43MDN6Ii8+PHBhdGggZD0ibTEwNS4yNjkgMTc3Ljc2aDIyLjcwM3YyMi43MDNoLTIyLjcwM3oiLz48cGF0aCBkPSJtMTUwLjY3NSAxNzcuNzZoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIvPjwvZz48cGF0aCBkPSJtODIuNjIyIDE3Ny43NmgyMi43MDN2MjIuNzAzaC0yMi43MDN6IiBmaWxsPSIjY2VjZWNlIi8+PHBhdGggZD0ibTEyNy45NzIgMTc3Ljc2aDIyLjcwM3YyMi43MDNoLTIyLjcwM3oiIGZpbGw9IiNjZWNlY2UiLz48cGF0aCBkPSJtMTczLjM3OCAxNzcuNzZoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIgZmlsbD0iI2NlY2VjZSIvPjwvZz48Zz48ZyBmaWxsPSIjY2VjZWNlIj48cGF0aCBkPSJtNTkuOTE5IDIwMC40NjNoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIvPjxwYXRoIGQ9Im0xMDUuMjY5IDIwMC40NjNoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIvPjxwYXRoIGQ9Im0xNTAuNjc1IDIwMC40NjNoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIvPjwvZz48cGF0aCBkPSJtODIuNjIyIDIwMC40NjNoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIgZmlsbD0iI2FmYWZhZiIvPjxwYXRoIGQ9Im0xMjcuOTcyIDIwMC40NjNoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIgZmlsbD0iI2FmYWZhZiIvPjxwYXRoIGQ9Im0xNzMuMzc4IDIwMC40NjNoMjIuNzAzdjIyLjcwM2gtMjIuNzAzeiIgZmlsbD0iI2FmYWZhZiIvPjwvZz48L2c+PC9zdmc+"
+    },
+    "design": {
+        "board": "Python3-Noetic",
+        "graph": {
+            "blocks": [
+                {
+                    "id": "c686937b-7fcb-438c-8aa7-24f9241b8d13",
+                    "type": "basic.input",
+                    "data": {
+                        "name": "Img"
+                    },
+                    "position": {
+                        "x": 336,
+                        "y": 450
+                    }
+                },
+                {
+                    "id": "b7aacaae-dcb9-446b-a576-45055e4388fe",
+                    "type": "basic.input",
+                    "data": {
+                        "name": "Enable"
+                    },
+                    "position": {
+                        "x": 335,
+                        "y": 632
+                    }
+                },
+                {
+                    "id": "2a466c9d-1eb5-4148-904a-e9a4fa320ad8",
+                    "type": "basic.output",
+                    "data": {
+                        "name": "Out"
+                    },
+                    "position": {
+                        "x": 1445,
+                        "y": 537
+                    }
+                },
+                {
+                    "id": "1a4663d0-c299-4757-96cc-ddd12f7c03be",
+                    "type": "basic.code",
+                    "data": {
+                        "code": "import cv2\nimport numpy as np\n\ndef main(inputs, outputs, parameters, synchronise):\n    auto_enable = False\n    try:\n        enable = inputs.read_number(\"Enable\")\n    except Exception:\n        auto_enable = True\n\n    while(auto_enable or inputs.read_number('Enable')):\n        frame = inputs.read_image(\"Img\")\n        if frame is None:\n            continue\n\n        inverted_img = cv2.bitwise_not(frame)\n        outputs.share_image('Out', inverted_img)\n        synchronise()",
+                        "frequency": "30",
+                        "params": [],
+                        "ports": {
+                            "in": [
+                                {
+                                    "name": "Img"
+                                },
+                                {
+                                    "name": "Enable"
+                                }
+                            ],
+                            "out": [
+                                {
+                                    "name": "Out"
+                                }
+                            ]
+                        },
+                        "size": {
+                            "width": "420px",
+                            "height": "400px"
+                        }
+                    },
+                    "position": {
+                        "x": 488,
+                        "y": 219
+                    }
+                }
+            ],
+            "wires": [
+                {
+                    "source": {
+                        "block": "1a4663d0-c299-4757-96cc-ddd12f7c03be",
+                        "port": "Out",
+                        "name": "Out"
+                    },
+                    "target": {
+                        "block": "2a466c9d-1eb5-4148-904a-e9a4fa320ad8",
+                        "port": "output-in",
+                        "name": "output-in"
+                    }
+                },
+                {
+                    "source": {
+                        "block": "c686937b-7fcb-438c-8aa7-24f9241b8d13",
+                        "port": "input-out",
+                        "name": "Img"
+                    },
+                    "target": {
+                        "block": "1a4663d0-c299-4757-96cc-ddd12f7c03be",
+                        "port": "Img",
+                        "name": "Img"
+                    }
+                },
+                {
+                    "source": {
+                        "block": "b7aacaae-dcb9-446b-a576-45055e4388fe",
+                        "port": "input-out",
+                        "name": "Enable"
+                    },
+                    "target": {
+                        "block": "1a4663d0-c299-4757-96cc-ddd12f7c03be",
+                        "port": "Enable",
+                        "name": "Enable"
+                    }
+                }
+            ]
+        }
+    },
+    "dependencies": {}
+}


### PR DESCRIPTION
Description:
Replaces PR #427

Summary
This PR introduces the new ImageInvert block to the OpenCV collection.

Based on the feedback in #427, I have drastically scoped down this Pull Request to contain only the essential files for the block, removing any external engine modifications.

Key Changes
Isolated Block Schema (

ImageInvert.json
): Added the block schema with inputs for Img and Enable.
Natively Supports UUID Wiring: I discovered that my previous synthesis mapping crashes were caused by residual BlurType and Kernel phantom ports left over in the raw JSON schema. I have completely cleaned the JSON structure so that synthesis.py can now map the blocks seamlessly using its default UUID-based wire mapping feature exactly as intended!
Execution Logic: Implemented standard color inversion correctly using cv2.bitwise_not().
Registry Update: Registered the block in 

collection-factory.tsx
.
Verification locally
Successfully booted the local VisualCircuit interface.
Created a standard pipeline: Camera -> ImageInvert -> Screen.
Verified that the synthesis engine successfully compiled the connections and outputted a flawlessly inverted stream from the camera.
