### PR TITLE
Fix #443: narrow bare except and remove dead code in inputs.py

### DIFF
--- a/backend/staticfiles/synthesis/lib/inputs.py
+++ b/backend/staticfiles/synthesis/lib/inputs.py
@@ -1,4 +1,4 @@
-from multiprocessing import shared_memory, Condition
+from multiprocessing import shared_memory
 
 import numpy as np
 from lib.exceptions import InvalidInputNameException
@@ -13,12 +13,11 @@ def create_readonly_wire(name):
     return shm
 
 def create_number_wire(name, size):
-        try:
-            shm = shared_memory.SharedMemory(name=name)
-        except:
-            shm = shared_memory.SharedMemory(name=name, create=True, size=size)
-        # self.shms.append(shm)
-        return shm
+    try:
+        shm = shared_memory.SharedMemory(name=name)
+    except FileNotFoundError:
+        shm = shared_memory.SharedMemory(name=name, create=True, size=size)
+    return shm
 
 class Inputs:
 
@@ -27,11 +26,6 @@ class Inputs:
     def __init__(self, input_data) -> None:
         self.inputs = input_data
         self._enable_data = self.inputs[Inputs.ENABLE_NAME] if Inputs.ENABLE_NAME in self.inputs else None
-
-    def _init_enabled(self) -> None:
-        # This function is redundant for now, its not being used anywhere
-        self._enable_data = self.inputs[Inputs.ENABLE_NAME] if Inputs.ENABLE_NAME in self.inputs else None
-        self._enable_condition = Condition(self.inputs[Inputs.ENABLE_NAME]["lock"]) if self.enable_wire else None
 
     def read(self, name):
         if self.inputs.get(name) is None:
@@ -196,12 +190,10 @@ class Inputs:
 
 
         else:
-            # Wire doesn't exist yet, ideally has to be created and set
-            # TODO: Is this case necessary?
-            # Yep case is definitely necessary especially by this implementation
-            
+            # Wire doesn't exist yet: this implementation requires it to be
+            # created and set here.
             if _enabled:
-            # If the command has been give to enable the wire     
+                # The command has been given to enable the wire
                 wire_name = self._enable_data["wire"]
                 # Value of the wire to be set
                 wire_val = np.array([1])


### PR DESCRIPTION
Fixes #443 @jmplaza @BkPankaj 
### Changes in `backend/staticfiles/synthesis/lib/inputs.py`

1. **Narrowed the bare `except:`** in `create_number_wire()` to `except FileNotFoundError:`. A bare except also swallows `KeyboardInterrupt`/`SystemExit` and can hide real bugs; `FileNotFoundError` is the specific exception `SharedMemory(name=...)` raises when the block doesn't exist yet, and matches how `create_readonly_wire()` already handles it. Also normalized the function's indentation to 4 spaces.
2. **Removed the unused `_init_enabled()` method.** Its own comment marked it redundant, a repo-wide grep finds no callers, and it references a non-existent `self.enable_wire` attribute, so it would raise `AttributeError` if ever called.
3. **Removed the now-unused `Condition` import** (it was only referenced by the deleted method) and a leftover commented-out line (`# self.shms.append(shm)`), which referenced `self` inside a plain function.
4. **Converted the resolved TODO** in the `enabled` setter into a normal explanatory comment, per the issue.

### Verification
- `python -m py_compile backend/staticfiles/synthesis/lib/inputs.py` passes
- `grep -rn "_init_enabled"` across the repo returns no remaining references

Diff: 1 file, +9/−17.

<img width="546" height="51" alt="image" src="https://github.com/user-attachments/assets/a8404fee-a7f5-4f42-bab8-62aaf0892fcc" />

<img width="983" height="68" alt="image" src="https://github.com/user-attachments/assets/c9a5bfe7-5879-4b24-a2c5-ab161afb4e95" />
